### PR TITLE
Precook z3c.jbot registered templates.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Precook z3c.jbot registered templates. [jone]
 
 
 1.0.0 (2016-10-03)


### PR DESCRIPTION
Precook all templates registered in z3c.jbot when accessing the site the first time.

I couldn't find a way to test that reliably, therefore I did not write tests. But I did verify that the templates are actually compiled in a running site.
