### PR TITLE
Skip persistent templates in precook_templates()

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Skip persistent templates in precook_templates() to avoid attempting to
+  operate on a closed ZODB connection. [lgraf]
 
 
 1.1.1 (2016-11-21)

--- a/ftw/chameleon/precook.py
+++ b/ftw/chameleon/precook.py
@@ -37,6 +37,19 @@ def precook_templates():
 
         msg = 'Pre-cooking {} templates.'.format(len(templates))
         for template in ProgressLogger(msg, templates, logger=LOG):
+            if hasattr(template, '_p_jar'):
+                # Skip persistent templates - portal_skins templates will be
+                # cooked later on the first request, and we don't care about
+                # precooking Zope App level templates.
+                #
+                # This is to avoid attempting to access persistent objects on
+                # a closed ZODB connection after exceptions (ZODB.Connection
+                # Shouldn't load state for [OID] when the connection is closed)
+                #
+                # We're deliberately checking for '_p_jar' instead of
+                # IPersistent.providedBy(template) because the latter also
+                # triggers loading of the object state.
+                continue
             if not hasattr(template, '_cook_check'):
                 continue
 

--- a/ftw/chameleon/tests/test_precook.py
+++ b/ftw/chameleon/tests/test_precook.py
@@ -2,6 +2,7 @@ from ftw.chameleon.precook import eager_load_portal_skins
 from ftw.chameleon.precook import precook_templates
 from ftw.chameleon.precook import SKINS_PRECOOKED_FOR_SITES
 from ftw.chameleon.tests import FunctionalTestCase
+from Products.PageTemplates import ZopePageTemplate
 import os
 
 
@@ -27,6 +28,14 @@ class TestPrecookTemplates(FunctionalTestCase):
         self.assertFalse(self.is_view_template_cooked(view))
         precook_templates()
         self.assertTrue(self.is_view_template_cooked(view))
+
+    def test_doesnt_precook_persistent_templates(self):
+        # Using ZopePageTemplate.manage_addPageTemplateForm as an example of
+        # a persistent template here
+        template = ZopePageTemplate.manage_addPageTemplateForm
+        self.assertIsNone(template._v_program)
+        precook_templates()
+        self.assertIsNone(template._v_program)
 
     def is_view_template_cooked(self, view):
         return bool(view.template.im_func._v_program)

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ tests_require = [
     'ftw.testing',
     'plone.app.testing',
     'testfixtures',
+    'Zope2',
 ]
 
 extras_require = {


### PR DESCRIPTION
Skip persistent templates in `precook_templates()` to avoid attempting to operate on a closed ZODB connection.

This fixes `ZODB.Connection Shouldn't load state for [OID] when the connection is closed` errors on instance startup after an exception happened during template cooking.

`portal_skins` templates will be cooked later on the first request, and we don't care about precooking Zope App level templates.

---

_I'm not particularly happy about the test (depending on some random template / package, I happened to choose `Products.PageTemplates.ZopePageTemplate.manage_addPageTemplateForm`), but it's a test, and it does indeed fail without this change._

Fixes #2 