### PR TITLE
Add changelog to long description of package

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Append changelog to long description of package [raphael-s]
 
 
 1.1.2 (2017-06-26)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+import os
 
 version = '1.1.3.dev0'
 
@@ -18,7 +19,8 @@ setup(
     name='ftw.chameleon',
     version=version,
     description='Enhance Chameleon templating engine integration into Plone',
-    long_description=open('README.rst').read(),
+    long_description=open('README.rst').read() + '\n' + open(
+        os.path.join('docs', 'HISTORY.txt')).read(),
 
     # Get more strings from
     # http://www.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
This adds the changelog from `docs/HISTORY.txt` to the long description of the package.
The changelog will now be visible on the packages pages like github and pypi. 

Sadly I can't test this on any real website which would display it, so here's how it looks with longtest 😄 
<img width="823" alt="screen shot 2017-06-27 at 18 17 43" src="https://user-images.githubusercontent.com/16755391/27598201-16995a60-5b65-11e7-9409-4b29b7988e04.png">

closes #4 