### PR TITLE
Require "five.pt" < 3.0.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
+- Require five.pt < 3.0. [mbaechtold]
+
 - Append changelog to long description of package [raphael-s]
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         'Plone',
         'collective.monkeypatcher',
-        'five.pt',
+        'five.pt < 3.0',
         'setuptools',
     ],
 


### PR DESCRIPTION
"five.pt" has been marked as deprecated as the code has been integrated into "Zope2" >= 4. So they removed all the code from "five.pt" and released "five.pt" 3.0 which requires "Zope2" >= 4.0a2.

We cannot yet update to "Zope2" >= 4 so we need to use an older release of "five.pt".