### PR TITLE
Fix tests by constraining `mock` version:

### DIFF
--- a/test-plone-5.1.x.cfg
+++ b/test-plone-5.1.x.cfg
@@ -12,3 +12,7 @@ package-name = ftw.chameleon
 initialization +=
     import os
     os.environ.pop('CHAMELEON_CACHE', None)
+
+[versions]
+# testfixtures == 6.18.5 requires a recent version of the mock backport
+mock = >2.0.0,<4.0.0


### PR DESCRIPTION
The `testfixtures` dependency in version 6.18.5 requires `mock > 2.0.0` (for its functionality) but `< 4.0.0` (because that version wouldn't be compatible with Python 2.7 any more).

Fixes test failures like [these](https://ci.4teamwork.ch/builds/540971/tasks/1053579).