### PR TITLE
Pin chameleon to last Python2 compatible version.

### DIFF
--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -14,4 +14,5 @@ initialization +=
     os.environ.pop('CHAMELEON_CACHE', None)
 
 [versions]
-chameleon = <4.0.0
+chameleon = <4.0.0  # For python2 compatibility
+z3c.pt = <4.0  # For python2 compatibility

--- a/test-plone-4.3.x.cfg
+++ b/test-plone-4.3.x.cfg
@@ -12,3 +12,6 @@ package-name = ftw.chameleon
 initialization +=
     import os
     os.environ.pop('CHAMELEON_CACHE', None)
+
+[versions]
+chameleon = <4.0.0


### PR DESCRIPTION
- `chameleon` 4 is no longer python2 compatible (https://github.com/malthe/chameleon/blob/master/CHANGES.rst#400-2023-03-06)
- `z3c.pt 4` is no longer python2 compatible (https://github.com/zopefoundation/z3c.pt/blob/master/CHANGES.rst#40-2023-03-27)

Should fix failing nightly builds.